### PR TITLE
fix: the denomination of maxFee

### DIFF
--- a/common/simulation/L2/Optimism/Optimism.ts
+++ b/common/simulation/L2/Optimism/Optimism.ts
@@ -41,7 +41,9 @@ export const calcOptimismPreVerificationGas = async (
   const l2PriorityFee = baseFeePerGas + Number(userOp.maxPriorityFeePerGas);
 
   const l2Price = l2MaxFee < l2PriorityFee ? l2MaxFee : l2PriorityFee;
-  const extraPvg = l1Fee.div(l2Price);
+
+  const l2PriceBigNumber = ethers.BigNumber.from(l2Price).mul('1000000000');
+  const extraPvg = l1Fee.div(l2PriceBigNumber);
 
   return extraPvg.toNumber();
 };


### PR DESCRIPTION
this https://github.com/bcnmy/bundler/pull/246/commits/06ab75391d0d41f7277e4de4a2a52dcecfb0c788 commit changed the base from `140000000` to fetch it on chain, which now sends 1. It needs to be converted to 1e9 and then send it on chain.