### PR TITLE
Radu increase bundler pod memory env

### DIFF
--- a/k8s/relayer/templates/statefulset.yaml
+++ b/k8s/relayer/templates/statefulset.yaml
@@ -51,6 +51,9 @@ spec:
         image: {{ .Values.relayer.image }}
         ports:
         - containerPort: {{ .Values.relayer.port }}
+        env:
+          - name: NODE_OPTIONS
+            value: "=--max_old_space_size=6000"
         envFrom:
           {{- if .Values.datadog.enable }}
           - configMapRef:

--- a/k8s/relayer/values.staging.yaml
+++ b/k8s/relayer/values.staging.yaml
@@ -6,6 +6,8 @@ relayer:
   image: "gcr.io/biconomy-staging/sdk/relayer-node-service:latest"
   port: "3000"
   replicaCount: 1
+  # Increase also the value for NODE_OPTIONS --max_old_space_size
+  # in statefulset.yaml
   resource:
     requests:
       memory: "6000Mi"


### PR DESCRIPTION
# Description

increase the memory available to nodejs 

this seems to have worked 

```bash
kubectl -n sdk-staging get pods | grep rel
relayer-server0-0                                          1/1     Running   0                 2m48s
relayer-server1-0                                          1/1     Running   0                 19h

kubectl -n sdk-staging exec -it relayer-server0-0 -- /bin/sh -c 'printenv | grep -E ^NODE_'
NODE_VERSION=18.17.1
NODE_OPTIONS==--max_old_space_size=6000

```