### PR TITLE
increased pvg based on new logic

### DIFF
--- a/common/simulation/BundlerSimulationService.ts
+++ b/common/simulation/BundlerSimulationService.ts
@@ -239,6 +239,18 @@ export class BundlerSimulationService {
           preVerificationGas += 50000;
         }
 
+        if (OptimismNetworks.includes(chainId) || ArbitrumNetworks.includes(chainId)) {
+          if (totalGas < 500000) {
+            preVerificationGas += 30000;
+          } else if (totalGas > 500000 && totalGas < 1000000) {
+            preVerificationGas += 65000;
+          } else if (totalGas > 1000000 && totalGas < 2000000) {
+            preVerificationGas += 150000;
+          } else {
+            preVerificationGas += 200000;
+          }
+        }
+
         if (callGasLimit > 500000) {
           callGasLimit += 100000;
         }


### PR DESCRIPTION
# Description

<!-- Please include a summary of the changes and the related issue. Please also include relevant motivation and context. List any dependencies that are required for this change. -->

- Increased pvg based on new calculation for OP and Arb based networks
-  New calc: 
```
   if (OptimismNetworks.includes(chainId) || ArbitrumNetworks.includes(chainId)) {
        if (totalGas < 500000) {
          preVerificationGas += 30000;
        } else if (totalGas > 500000 && totalGas < 1000000) {
          preVerificationGas += 65000;
        } else if (totalGas > 1000000 && totalGas < 2000000) {
          preVerificationGas += 150000;
        } else {
          preVerificationGas += 200000;
        }
      }
```