### PR TITLE
not using state overrides on Astar RPCs

### DIFF
--- a/common/constants/index.ts
+++ b/common/constants/index.ts
@@ -64,3 +64,4 @@ export const ArbitrumNetworks = [42170, 421613, 42161];
 export const AlchemySimulateExecutionSupportedNetworks = [
   1, 5, 137, 80001, 10, 420, 42161, 421613, 8453, 84531, 592,
 ];
+export const AstarNetworks = [81, 592];

--- a/common/simulation/BundlerSimulationService.ts
+++ b/common/simulation/BundlerSimulationService.ts
@@ -29,6 +29,7 @@ import {
   ArbitrumNetworks,
   LineaNetworks,
   AlchemySimulateExecutionSupportedNetworks,
+  AstarNetworks,
 } from '../constants';
 import { AlchemySimulationService, TenderlySimulationService } from './external-simulation';
 import { calcArbitrumPreVerificationGas, calcOptimismPreVerificationGas } from './L2';
@@ -146,8 +147,8 @@ export class BundlerSimulationService {
       let ethCallParams;
 
       // polygon zk evm nodes don't support state overrides
-      if (PolygonZKEvmNetworks.includes(chainId)) {
-        log.info('Request on polygon zk evm hence not doing state overrides in eth_call');
+      if (PolygonZKEvmNetworks.includes(chainId) || AstarNetworks.includes(chainId)) {
+        log.info(`Request on RPC that does not support state overrides on chainId: ${chainId}`);
         ethCallParams = [
           {
             from: '0x0000000000000000000000000000000000000000',


### PR DESCRIPTION
# Description

<!-- Please include a summary of the changes and the related issue. Please also include relevant motivation and context. List any dependencies that are required for this change. -->

- Blast API does not support state overrides hence not overriding sender account balance