### PR TITLE
increased gas price frequency to once per hour

### DIFF
--- a/src/config/static-config.json
+++ b/src/config/static-config.json
@@ -236,7 +236,7 @@
       "11155111": 60,
       "80085": 60,
       "84532": 60,
-      "168587773": 60
+      "168587773": 3600
     }
   },
   "defaultGasOverheads": {
@@ -648,7 +648,8 @@
         "unable to complete request at this time",
         "timeout",
         "we can't execute this request",
-        "rate limit exceeded"
+        "rate limit exceeded",
+        "sender is over rate limit"
       ],
       "INTRINSIC_GAS_TOO_LOW": ["intrinsic gas too low"],
       "MAX_FEE_PER_GAS_LESS_THAN_BLOCK_BASE_FEE": [


### PR DESCRIPTION
# Description

<!-- Please include a summary of the changes and the related issue. Please also include relevant motivation and context. List any dependencies that are required for this change. -->

- increasing gas price interval to once per hour on blast to prevent rate limiting
- added RPC rate limiting msg to handle retries