### PR TITLE
gas estimations package updated to fix mantle pvg

### DIFF
--- a/package.json
+++ b/package.json
@@ -32,7 +32,7 @@
     "crypto-js": "^4.1.1",
     "dd-trace": "^4.17.0",
     "dotenv": "^16.0.3",
-    "entry-point-gas-estimations": "0.0.15",
+    "entry-point-gas-estimations": "0.0.17",
     "ethereumjs-util": "^7.1.5",
     "express": "^4.18.2",
     "express-handlebars": "^6.0.6",

--- a/yarn.lock
+++ b/yarn.lock
@@ -3957,10 +3957,10 @@ end-of-stream@^1.1.0:
   dependencies:
     once "^1.4.0"
 
-entry-point-gas-estimations@0.0.15:
-  version "0.0.15"
-  resolved "https://registry.yarnpkg.com/entry-point-gas-estimations/-/entry-point-gas-estimations-0.0.15.tgz#75de6b8579ede23f258e270a7b470a45932f03d3"
-  integrity sha512-dRowcDDjqB6qv7PIzgY0ikJ7qYCNF+8DoZWihQFPKMqwNBi8T3HSTczpcAfGTeplzkwV+R6Bp+73YjYIwn7qQw==
+entry-point-gas-estimations@0.0.17:
+  version "0.0.17"
+  resolved "https://registry.yarnpkg.com/entry-point-gas-estimations/-/entry-point-gas-estimations-0.0.17.tgz#4893f5faac3259ecd458e1d374dede1ef42f9997"
+  integrity sha512-Def6CDpjJlhAdt52OQ/r+llrmkXaLGV1oZN2/gZijvGqf7ODkjfGXbHShVwakjl0+aJLqgyOiQZcv4VC0MTnfA==
   dependencies:
     "@types/node" "^20.10.5"
     eslint-plugin-tsdoc "^0.2.17"


### PR DESCRIPTION
# 📖 Context
## Type of change

<!-- Please delete options that are not relevant. -->

- [ ] Non-breaking change (backwards compatible)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Why are we doing this?

<!-- Describe why is this PR important, examples below for inspiration: -->

- To get the correct preVerificationGas value from the latest gas estimation package

## What did we do?

<!-- Describe how we solved the problem described in the previous section, for example -->

- PVG formula was updated in the package to reflect the correct one

## How Has This Been Tested?

<!-- Explain how you tested the expected behavior described in the previous section. If you tested manually, explain how. If there are unit tests describe what they do. For example: -->

- Tested this manually by sending a user op on Mantle network

