### PR TITLE
small nonce error catch for astar chains

### DIFF
--- a/config/default.json
+++ b/config/default.json
@@ -747,7 +747,7 @@
         "insufficient funds for transfer",
         "insufficient funds for gas * price + value"
       ],
-      "NONCE_TOO_LOW": ["nonce too low", "nonce has already been used"],
+      "NONCE_TOO_LOW": ["nonce too low", "nonce has already been used", "lower than the current nonce of the account"],
       "MAX_PRIORITY_FEE_HIGHER_THAN_MAX_FEE": [
         "max priority fee per gas higher than max fee per gas",
         "cannot be higher than the fee cap"


### PR DESCRIPTION
# 📖 Context
## Type of change

<!-- Please delete options that are not relevant. -->

- [x] Non-breaking change (backwards compatible)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Why are we doing this?

<!-- Describe why is this PR important, examples below for inspiration: -->

- getting low nonce error on astar testnet. The error message is not stored with us

## What did we do?

<!-- Describe how we solved the problem described in the previous section, for example -->

- Added the error message in the known error messages
