### PR TITLE
added blast to networks not supporting state overrides

### DIFF
--- a/config/default.json
+++ b/config/default.json
@@ -1000,7 +1000,7 @@
   "blastPvgValue": 700000000,
   "scrollNetworks": [534351, 534352],
   "networksNotSupportingEthCallStateOverrides": [
-    1101, 1442, 81, 592, 169, 3441005, 91715, 7116, 9980, 88882, 88888
+    1101, 1442, 81, 592, 169, 3441005, 91715, 7116, 9980, 88882, 88888, 81457
   ],
   "networksNotSupportingEthCallBytecodeStateOverrides": [
     1, 59140, 59144, 84532, 421614, 168587773, 80001, 43113, 11155111, 1101,

--- a/src/common/simulation/BundlerSimulationService.ts
+++ b/src/common/simulation/BundlerSimulationService.ts
@@ -278,7 +278,7 @@ export class BundlerSimulationService {
         },
       };
     } catch (error: any) {
-      log.error(`Error in estimating user op: ${parseError(error)}`);
+      log.error(`Error in estimating user op: ${parseError(error)} on chainId: ${estimateUserOperationGasData.chainId}`);
       return {
         code: error.code,
         message: parseError(error),
@@ -508,7 +508,7 @@ export class BundlerSimulationService {
       log.info(
         `Response from eth_estimateGas: ${customJSONStringify(
           ethEstimatGasResponse,
-        )}`,
+        )} on chainId: ${chainId}`,
       );
 
       const ethEstimateGasError = ethEstimatGasResponse.error;


### PR DESCRIPTION
# 📖 Context
## Type of change

<!-- Please delete options that are not relevant. -->

- [x] Non-breaking change (backwards compatible)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Why are we doing this?

<!-- Describe why is this PR important, examples below for inspiration: -->

- Blast RPC not returning the correct responses

<!-- If there's no ticket, delete this -->

## What did we do?

<!-- Describe how we solved the problem described in the previous section, for example -->

- Using the standard way of doing estimations

