### PR TITLE
added zetachain to networksNotSupportingEthCallStateOverrides

### DIFF
--- a/config/default.json
+++ b/config/default.json
@@ -1101,7 +1101,7 @@
   "blastPvgValue": 700000000,
   "scrollNetworks": [534351, 534352],
   "networksNotSupportingEthCallStateOverrides": [
-    1101, 1442, 81, 592, 169, 3441005, 91715, 7116, 9980, 88882, 88888, 81457, 666666666, 2442, 8101902
+    1101, 1442, 81, 592, 169, 3441005, 91715, 7116, 9980, 88882, 88888, 81457, 666666666, 2442, 8101902, 7001
   ],
   "trustWalletSupportedNetworks": [137, 80001, 56, 204, 42161, 10, 8453],
   "networksNotSupportingEthCallBytecodeStateOverrides": [


### PR DESCRIPTION
# 📖 Context
## Type of change

<!-- Please delete options that are not relevant. -->

- [x] Non-breaking change (backwards compatible)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Why are we doing this?

<!-- Describe why is this PR important, examples below for inspiration: -->

- Zetachainn testnet was facing the following error:
```
{
    "jsonrpc": "2.0",
    "id": 1,
    "error": {
        "code": -32002,
        "message": "Cannot decode zero data (\"0x\") with ABI parameters.\n\nVersion: viem@2.9.3"
    }
}
```
- The error was coming from gas estimation package when we were using state override to estimate gas

<!-- If there's no ticket, delete this -->

Related issues:
- link to issue / ticket

## What did we do?

<!-- Describe how we solved the problem described in the previous section, for example -->

- Now using the default way to estimate gas without using state overrides

## How Has This Been Tested?

<!-- Explain how you tested the expected behavior described in the previous section. If you tested manually, explain how. If there are unit tests describe what they do. For example: -->

- Tested by using the same payload that was giving an error and now after the fix it returns the correct estimations