### PR TITLE
added op sepolia pvgMarkUp and a default value

### DIFF
--- a/config/default.json
+++ b/config/default.json
@@ -1159,7 +1159,8 @@
     "4653": 0.15,
     "5003": 0.15,
     "8101902": 0.15, 
-    "666666666": 0.15
+    "666666666": 0.15,
+    "11155420": 0.15
   },
   "socketService": {
     "wssUrl": "wss://sdk-ws.prod.biconomy.io/connection/websocket",

--- a/src/common/simulation/BundlerSimulationService.ts
+++ b/src/common/simulation/BundlerSimulationService.ts
@@ -258,9 +258,11 @@ export class BundlerSimulationService {
         BigInt(verificationGasLimitMultiplier) * verificationGasLimit +
         preVerificationGas;
       log.info(`totalGas: ${totalGas} on chainId: ${chainId}`);
+      
+      const pvgMarkUp = config.pvgMarkUp[chainId] || 0.10; // setting default pvgMarkUp to 10% incase the value for a given chainId is not set
 
       preVerificationGas += BigInt(
-        Math.ceil(Number(toHex(totalGas)) * config.pvgMarkUp[chainId]),
+        Math.ceil(Number(toHex(totalGas)) * pvgMarkUp),
       );
 
       log.info(


### PR DESCRIPTION
# 📖 Context
## Type of change

<!-- Please delete options that are not relevant. -->

- [x] Non-breaking change (backwards compatible)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Why are we doing this?

<!-- Describe why is this PR important, examples below for inspiration: -->

- We were getting a Nan error on this chain

## What did we do?

<!-- Describe how we solved the problem described in the previous section, for example -->

- Added op sepolia chained config in pvgMarkUp object and a default value so that if it ever gets undefined we can use it
