### PR TITLE
added x layer to networksNotSupportingEthCallStateOverrides

### DIFF
--- a/config/default.json
+++ b/config/default.json
@@ -1043,7 +1043,7 @@
   "blastPvgValue": 700000000,
   "scrollNetworks": [534351, 534352],
   "networksNotSupportingEthCallStateOverrides": [
-    1101, 81, 592, 169, 3441005, 91715, 7116, 9980, 88882, 88888, 81457, 666666666, 2442, 8101902, 7001
+    1101, 81, 592, 169, 3441005, 91715, 7116, 9980, 88882, 88888, 81457, 666666666, 2442, 8101902, 7001, 196, 195
   ],
   "trustWalletSupportedNetworks": [137, 56, 204, 42161, 10, 8453],
   "networksNotSupportingEthCallBytecodeStateOverrides": [


### PR DESCRIPTION
# 📖 Context
## Type of change

<!-- Please delete options that are not relevant. -->

- [x] Non-breaking change (backwards compatible)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Why are we doing this?

<!-- Describe why is this PR important, examples below for inspiration: -->

- Fixes a bug on x layer