### PR TITLE
fix(transaction-listener): :bug: fix onTransactionFailure handler

### DIFF
--- a/src/relayer/transaction-listener/EVMTransactionListener.ts
+++ b/src/relayer/transaction-listener/EVMTransactionListener.ts
@@ -1154,16 +1154,3 @@ export class EVMTransactionListener
     }
   }
 }
-
-export function calculateFrontRunnedTransactionFee(
-  frontRunnedTransactionReceipt: any,
-) {
-  // Cast to BigInt in case the returned value is a number
-  // If it's already a BigInt, it will remain the same
-  const gasUsed = BigInt(frontRunnedTransactionReceipt.gasUsed);
-  const effectiveGasPrice = BigInt(
-    frontRunnedTransactionReceipt.effectiveGasPrice,
-  );
-
-  return gasUsed * effectiveGasPrice;
-}


### PR DESCRIPTION
Fix bug that causes the following exception in `EVMTransactionListener.onTransactionFailure`:
```
frontRunnedTransactionReceipt.gasUsed.mul is not a function
```

# 📖 Context
## Type of change

- [x] Non-breaking change (backwards compatible)

## Why are we doing this?

- This probably won't fix the issue that was reported by the clients but this error repeatedly spamming the logs is driving me nuts.

## What did we do?

- Wrap the code that does multiplication with a try catch in case we encounter some weird formats.
- Replaced `mul()` with ordinary multiplication because the variables are not `Big.js` but `BigInt`

## How Has This Been Tested?

- 🚨 It wasn't tested at all