### PR TITLE
feat: enable-pdb

### DIFF
--- a/k8s/relayer/templates/poddisruptionbudget.yaml
+++ b/k8s/relayer/templates/poddisruptionbudget.yaml
@@ -1,0 +1,16 @@
+{{- if .Values.podDisruptionBudget.enable -}}
+apiVersion: policy/v1
+kind: PodDisruptionBudget
+metadata:
+  name: {{ .Values.name }}
+spec:
+{{- if .Values.podDisruptionBudget.minAvailable }}
+  minAvailable: {{ .Values.podDisruptionBudget.minAvailable | default 1 }}
+{{- end }}
+{{- if .Values.podDisruptionBudget.maxUnavailable }}
+  maxUnavailable: {{ .Values.podDisruptionBudget.maxUnavailable }}
+{{- end }}
+  selector:
+    matchLabels:
+      app: {{ .Values.name }}
+{{- end }}

--- a/k8s/relayer/values.prod.yaml
+++ b/k8s/relayer/values.prod.yaml
@@ -43,6 +43,11 @@ affinity_tolerations:
 startupProbe:
   failureThreshold: 120
 
+# Whether or not we want a pod disruption budget, enabled by default
+podDisruptionBudget:
+  enable: true
+  minAvailable: 1
+
 datadog:
   enable: true
   env: "production"


### PR DESCRIPTION
Moved from https://github.com/bcnmy/relayer-node/pull/10


```
$ helm template . -f values.prod.yaml 

---
# Source: relayers-service/templates/poddisruptionbudget.yaml
apiVersion: policy/v1
kind: PodDisruptionBudget
metadata:
  name: relayer-server
spec:
  minAvailable: 1
  selector:
    matchLabels:
      app: relayer-server
---
# Source: relayers-service/templates/service.yaml
apiVersion: v1
kind: Service
metadata:
  name: relayer-server0
  namespace: sdk-prod
  labels:
    helm.sh/chart: relayers-service-0.0.1
    app.kubernetes.io/name: relayers-service
    app.kubernetes.io/instance: release-name
    app.kubernetes.io/version: "v0.0.1"
    app.kubernetes.io/managed-by: Helm
spec:
  selector:
    app: relayer-server
    component: relayer-server0
  ports:
    - port: 3000
      targetPort: 3000
---
# Source: relayers-service/templates/statefulset.yaml
apiVersion: apps/v1
kind: StatefulSet
metadata:
  name: relayer-server0
  namespace: sdk-prod
  labels:
    app: relayer-server
    component: relayer-server0
    helm.sh/chart: relayers-service-0.0.1
    app.kubernetes.io/name: relayers-service
    app.kubernetes.io/instance: release-name
    app.kubernetes.io/version: "v0.0.1"
    app.kubernetes.io/managed-by: Helm
    tags.us5.datadoghq.com/env: production
    tags.us5.datadoghq.com/service: sdk-relayer-service
    tags.us5.datadoghq.com/version: v3.15.0
spec:
  serviceName: relayer-server
  replicas: 1
  selector:
    matchLabels:
      app: relayer-server
  template:
    metadata:
      labels:
        app: relayer-server
        tags.us5.datadoghq.com/env: production
        tags.us5.datadoghq.com/service: sdk-relayer-service
        tags.us5.datadoghq.com/version: v3.15.0
        admission.us5.datadoghq.com/config.mode: socket
        admission.us5.datadoghq.com/enabled: "true"
      annotations:
        admission.us5.datadoghq.com/js-lib.version: v3.16.0
        releaseTime: "2024-08-22 08:56:02Z" 
    spec:
      affinity:
        nodeAffinity:
          requiredDuringSchedulingIgnoredDuringExecution:
            nodeSelectorTerms:
            - matchExpressions:
              - key: app
                operator: In
                values:
                - relayer-server
      tolerations:
      - effect: NoSchedule
        key: app
        operator: Equal
        value: relayer-server
      containers:
      - name: relayer-server0
        image: gcr.io/biconomy-prod/sdk/relayer-node-service:latest
        imagePullPolicy: "Always"
        ports:
        - containerPort: 3000
        env:
          - name: NODE_OPTIONS
            value: "=--max_old_space_size=6000"
          - name: NODE_ENV
            value: production
          - name: NODE_CONFIG
            value: '{"relayer": {"nodePathIndex": 0}}'
        envFrom:
          - configMapRef:
              name: relayer-server-dd-configmap
          - secretRef:
              name: relayer-server-passphrase
        volumeMounts:
          - mountPath: "/home/nonroot/bundler/config.json.enc"
            name: secret-encrypted
            subPath: "config.json.enc"
          - mountPath: "/home/nonroot/bundler/config/production.json"
            name: secret-plain
            subPath: production.json
          - mountPath: /var/run/datadog
            name: apmsocketpath 
        resources:
          requests:
            memory: 6000Mi
            cpu: 4000m
          limits:
            memory: 6000Mi
            cpu: 4000m
        # allow in to total failureThreshold(30) * periodSeconds(10) = 300 seconds
        startupProbe:
          httpGet:
            path: /admin/startup
            port: 3000
          failureThreshold: 120
          successThreshold: 1
          periodSeconds: 10
        readinessProbe:
          httpGet:
            path: /health
            port: 3000
          initialDelaySeconds: 30
          periodSeconds: 30
          successThreshold: 1
          timeoutSeconds: 30
          failureThreshold: 3
        # cosider application not healhy after 10 minutes +
        livenessProbe:
          httpGet:
            path: /health
            port: 3000
          initialDelaySeconds: 120
          periodSeconds: 60
          successThreshold: 1
          timeoutSeconds: 120
          failureThreshold: 5
        lifecycle:
        # https://learnk8s.io/graceful-shutdown
        # still server traffic for 15 seconds after k8s issued the SIG term
          preStop:
            exec:
              command: ["sleep", "15"]
      volumes:
      - name: secret-encrypted
        secret:
          secretName: relayer-server0
      - name: secret-plain
        secret:
          secretName: relayer-server-plain
      - hostPath:
          path: /var/run/datadog/
        name: apmsocketpath
---
# Source: relayers-service/templates/secret.yaml
apiVersion: kubernetes-client.io/v1
kind: ExternalSecret
metadata:
  name: relayer-server0
  namespace: sdk-prod
  labels:
    helm.sh/chart: relayers-service-0.0.1
    app.kubernetes.io/name: relayers-service
    app.kubernetes.io/instance: release-name
    app.kubernetes.io/version: "v0.0.1"
    app.kubernetes.io/managed-by: Helm

spec:
  backendType: gcpSecretsManager
  projectId: biconomy-prod
  data:
  - key:  sdk-prod-relayer-node-service-0
    name: config.json.enc
```