### PR TITLE
handling gnosis fetching gas fees using viem

### DIFF
--- a/src/common/network/EVMNetworkService.ts
+++ b/src/common/network/EVMNetworkService.ts
@@ -26,6 +26,7 @@ import {
 import { logger } from "../logger";
 import { customJSONStringify, parseError } from "../utils";
 import { config } from "../../config";
+import { BLOCKCHAINS } from "../constants";
 
 const log = logger.child({
   module: module.filename.split("/").slice(-4).join("/"),
@@ -146,6 +147,19 @@ export class EVMNetworkService
   }
 
   async getEIP1559FeesPerGas(): Promise<Type2TransactionGasPriceType> {
+    // Using viem's estimateFeesPerGas instead of raw RPC call as Ankr sometimes
+    // gives unexpected errors
+    if (this.chainId === BLOCKCHAINS.GNOSIS_MAINNET) {
+      const {
+        maxFeePerGas,
+        maxPriorityFeePerGas
+      } = await this.provider.estimateFeesPerGas();
+
+      return {
+        maxFeePerGas: maxFeePerGas as bigint,
+        maxPriorityFeePerGas: maxPriorityFeePerGas as bigint
+      };
+    }
     const maxFeePerGasPromise = this.getLegacyGasPrice();
     const maxPriorityFeePerGasPromise = this.sendRpcCall(
       EthMethodType.MAX_PRIORITY_FEE_PER_GAS,


### PR DESCRIPTION
# 📖 Context
## Type of change

<!-- Please delete options that are not relevant. -->

- [X] Non-breaking change (backwards compatible)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Why are we doing this?

<!-- Describe why is this PR important, examples below for inspiration: -->

- @TheDivic figured the following: 
I figured out last night what’s going on, it’s a small fix I just don’t have the time to push it today.
The error “we can’t execute this request” comes exclusively from Ankr and people are regularly complaining about it (last message from [8 days ago](https://api-docs.ankr.com/discuss/6613e1521e5deb0018e78a2f)).
And when I looked at the logs it happens only in the GasPrice service when trying to fetch EIP1559 gas values.
We also call the GasPrice service when we check the user op for rejection, and that’s when the client encounters the error.
The reason is that for gas price we are using a raw RPC call (not viem) so it’s not using the fallback provider.
We should just add a public RPC or some other RPC as a fallback and update the EVMNetworkService.getEIP1559FeesPerGas to use viem.estimateFeesPerGas and it should work.


## What did we do?

<!-- Describe how we solved the problem described in the previous section, for example -->

- Used viem's `estimateFeePerGas` method instead of raw RPC call

## How Has This Been Tested?

<!-- Explain how you tested the expected behavior described in the previous section. If you tested manually, explain how. If there are unit tests describe what they do. For example: -->

- Tested this manually by sending a user op on the Gnosis mainnet
