### PR TITLE
fix(tw): :bug: Fix opBNB baseFeePerGas returning 0

### DIFF
--- a/config/default.json
+++ b/config/default.json
@@ -1038,5 +1038,11 @@
     "maxRedirections": 16,
     "retryDelayOnFailover": 100,
     "scaleReads": "master"
+  },
+  "gasOverrides": {
+    "204": {
+      "baseFeePerGas": 1,
+      "preVerificationGas": 2172916
+    }
   }
 }

--- a/src/common/simulation/BundlerSimulationService.ts
+++ b/src/common/simulation/BundlerSimulationService.ts
@@ -208,7 +208,12 @@ export class BundlerSimulationService {
         supportsEthCallByteCodeOverride = false;
       }
 
-      const baseFeePerGas = await this.gasPriceService.getBaseFeePerGas();
+      let baseFeePerGas = await this.gasPriceService.getBaseFeePerGas();
+      if (chainId === BLOCKCHAINS.OP_BNB_MAINNET && baseFeePerGas === 0n) {
+        baseFeePerGas = BigInt(
+          config.gasOverrides[BLOCKCHAINS.OP_BNB_MAINNET].baseFeePerGas,
+        );
+      }
 
       const response = await this.gasEstimator.estimateUserOperationGas({
         userOperation: userOp,
@@ -279,6 +284,12 @@ export class BundlerSimulationService {
 
       const end = performance.now();
       log.info(`Estimating the userOp took: ${end - start} milliseconds`);
+
+      if (chainId === BLOCKCHAINS.OP_BNB_MAINNET && baseFeePerGas === 0n) {
+        preVerificationGas = BigInt(
+          config.gasOverrides[BLOCKCHAINS.OP_BNB_MAINNET].preVerificationGas,
+        );
+      }
 
       return {
         code: STATUSES.SUCCESS,

--- a/src/config/interface/IConfig.ts
+++ b/src/config/interface/IConfig.ts
@@ -157,6 +157,13 @@ export type ConfigType = {
   // Transaction error messages
   transaction: TransactionConfigType;
   zeroAddress: `0x${string}`;
+  gasOverrides: Record<
+    number,
+    {
+      baseFeePerGas: number;
+      preVerificationGas: number;
+    }
+  >;
 };
 
 export interface IConfig {


### PR DESCRIPTION
# 📖 Context
## Type of change

- [x] Non-breaking change (backwards compatible)

## Why are we doing this?

- TW requests fail because baseFeePerGas returned from RPC is 0.

## What did we do?
Hardcoded PVG and baseFee.