### PR TITLE
feat(config): allow disabling fee validation for a target chain

### DIFF
--- a/config/default.json
+++ b/config/default.json
@@ -1044,5 +1044,6 @@
       "baseFeePerGas": 1,
       "preVerificationGas": 2172916
     }
-  }
+  },
+  "disableFeeValidation": []
 }

--- a/src/common/simulation/BundlerSimulationService.ts
+++ b/src/common/simulation/BundlerSimulationService.ts
@@ -543,7 +543,10 @@ export class BundlerSimulationService {
     );
     log.info(`Checking if maxPriorityFeePerGas is within acceptable limits`);
 
-    if (minimumAcceptableMaxPriorityFeePerGas > Number(maxPriorityFeePerGas)) {
+    if (
+      !config.disableFeeValidation.includes(this.networkService.chainId) &&
+      minimumAcceptableMaxPriorityFeePerGas > Number(maxPriorityFeePerGas)
+    ) {
       log.info(
         `maxPriorityFeePerGas in userOp: ${maxPriorityFeePerGas} is lower than expected maxPriorityFeePerGas: ${minimumAcceptableMaxPriorityFeePerGas}`,
       );
@@ -555,7 +558,10 @@ export class BundlerSimulationService {
     log.info(`maxPriorityFeePerGas is within acceptable limits`);
     log.info(`Checking if maxFeePerGas is within acceptable limits`);
 
-    if (minimumAcceptableMaxFeePerGas > Number(maxFeePerGas)) {
+    if (
+      !config.disableFeeValidation.includes(this.networkService.chainId) &&
+      minimumAcceptableMaxFeePerGas > Number(maxFeePerGas)
+    ) {
       log.info(
         `maxFeePerGas in userOp: ${maxFeePerGas} is lower than expected maxFeePerGas: ${minimumAcceptableMaxFeePerGas}`,
       );

--- a/src/config/interface/IConfig.ts
+++ b/src/config/interface/IConfig.ts
@@ -157,6 +157,7 @@ export type ConfigType = {
   // Transaction error messages
   transaction: TransactionConfigType;
   zeroAddress: `0x${string}`;
+  // hardcode override some gas values for a specific chain
   gasOverrides: Record<
     number,
     {
@@ -164,6 +165,8 @@ export type ConfigType = {
       preVerificationGas: number;
     }
   >;
+  // disable maxFeePerGas & maxPriorityFeePerGas validation for specific chain ids
+  disableFeeValidation: Array<number>;
 };
 
 export interface IConfig {


### PR DESCRIPTION
# 📖 Context
## Type of change

- [x] Non-breaking change (backwards compatible)

## Why are we doing this?

- This is enable specific clients to bypass validation and estimate their own gas values, risking failing transactions but possibly saving some gas.

Related issues:
- #690 

## What did we do?

If you add a chain ID to the `config.disableFeeValidation` array, the bundler won't validate the `maxFeePerGas` & `maxPriorityFeePerGas` fields in the received user op.

## How Has This Been Tested?

- It wasn't 🙁