### PR TITLE
fix(admin): :bug: Make healthchecks less sensitive to balance changes

### DIFF
--- a/src/common/status/StatusService.ts
+++ b/src/common/status/StatusService.ts
@@ -1,6 +1,5 @@
 /* eslint-disable import/no-import-module-exports */
 import nodeconfig from "config";
-import { parseEther } from "viem/utils";
 import { IEVMAccount } from "../../relayer/account";
 import { IRelayerManager } from "../../relayer/relayer-manager";
 import { ICacheService } from "../cache";
@@ -267,17 +266,11 @@ export class StatusService implements IStatusService {
           relayerManager.relayerQueue.get(address) ||
           relayerManager.transactionProcessingRelayerMap[address];
 
-        // this value is in ETH and we need to convert it to wei.
-        // This is confusing because the fundingBalanceThreshold is already parsed to wei
-        const fundingRelayerAmount = parseEther(
-          relayerManager.fundingRelayerAmount.toString(),
-        );
-
-        if (
-          relayer.balance < relayerManager.fundingBalanceThreshold &&
-          masterAccountBalance < fundingRelayerAmount
-        ) {
-          throw new Error(`Relayers for chainId: ${chainId} have low balance`);
+        const epsilonWei = 10; // a tiny amount greater than zero
+        if (relayer.balance < epsilonWei) {
+          throw new Error(
+            `Relayer with address: ${relayer.address} for chainId: ${chainId} is not funded`,
+          );
         }
       }
     });


### PR DESCRIPTION
Don't check if relayer's balance drops below the threshold in the healtcheck.

# 📖 Context
## Type of change

- [x] Non-breaking change (backwards compatible)

## Why are we doing this?
- Because the relayer balance often goes up and down as we are getting refunds, causing healthchecks to fail intermittently without reason.

Related issues:
- #692 

## What did we do?

- Disable some checks for `/admin/health/:chainId`

## How Has This Been Tested?

- Wasn't, we will have to test this in production, but it's a non breaking change and noting depends on this except the Cronitor status page that I am maintaining.
