### PR TITLE
fix: make logging async

### DIFF
--- a/src/common/logger/index.ts
+++ b/src/common/logger/index.ts
@@ -1,13 +1,19 @@
 import pino from "pino";
 
-const logger = pino({
-  // level: 'info', // Set the log level
-  transport: {
-    target: "pino-pretty",
-    options: {
-      colorize: true,
+const destination = pino.destination({ sync: false });
+
+// Create the logger using the asynchronous destination
+const logger = pino(
+  {
+    transport: {
+      target: "pino-pretty",
+      options: {
+        colorize: true,
+        destination: 1
+      },
     },
-  }, // ... other options
-});
+  },
+  destination
+);
 
 export { logger };


### PR DESCRIPTION
# 📖 Context
## Type of change

<!-- Please delete options that are not relevant. -->

- [x] Non-breaking change (backwards compatible)

## Why are we doing this?

<!-- Describe why is this PR important, examples below for inspiration: -->

- The service was crashing on production because of ```Error: _flushSync took too long (10s)```

## What did we do?

<!-- Describe how we solved the problem described in the previous section, for example -->

Per internet suggestions, changed the mode from sync to async, as to avoid crashing (give the thread execution some breathing space)
## How Has This Been Tested?

<!-- Explain how you tested the expected behavior described in the previous section. If you tested manually, explain how. If there are unit tests describe what they do. For example: -->

- Tested this manually by sending a user op on the Y network and ...
- Added unit tests that check if ...

# 👀 How do I review this?

<!-- 🔥 This section is **OPTIONAL** but it's very important, explain to your colleagues what to pay attention to and if they need to run something locally, explain how they do it.
If it's something very obvious or small, you can just delete this whole section. -->

- Check the parameters in file ... and compare them to ...
- To test this you first need to checkout this branch and run the following command ...
