### PR TITLE
json logging instead of pretty priny

### DIFF
--- a/src/common/logger/index.ts
+++ b/src/common/logger/index.ts
@@ -3,17 +3,6 @@ import pino from "pino";
 const destination = pino.destination({ sync: false });
 
 // Create the logger using the asynchronous destination
-const logger = pino(
-  {
-    transport: {
-      target: "pino-pretty",
-      options: {
-        colorize: true,
-        destination: 1
-      },
-    },
-  },
-  destination
-);
+const logger = pino({}, destination);
 
 export { logger };


### PR DESCRIPTION
Pretty print should be avoided at all costs.

Lets use a simple json logging. Grafana offers a way to prettify JSON, so it won't be offloading that to the service machine, which is ideal.