### PR TITLE
feat(validation): enable overriding PVG validation

### DIFF
--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -1,4 +1,2 @@
 #!/usr/bin/env sh
 . "$(dirname -- "$0")/_/husky.sh"
-
-yarn run format

--- a/src/common/simulation/BundlerSimulationService.ts
+++ b/src/common/simulation/BundlerSimulationService.ts
@@ -583,24 +583,27 @@ export class BundlerSimulationService {
       );
     }
 
-    const { preVerificationGas: networkPreVerificationGas } =
-      await this.gasEstimator.calculatePreVerificationGas({
-        userOperation: userOp,
-        baseFeePerGas,
-      });
-    log.info(`networkPreVerificationGas: ${networkPreVerificationGas}`);
+    if (!config.disableFeeValidation.includes(this.networkService.chainId)) {
+      const { preVerificationGas: networkPreVerificationGas } =
+        await this.gasEstimator.calculatePreVerificationGas({
+          userOperation: userOp,
+          baseFeePerGas,
+        });
+      log.info(`networkPreVerificationGas: ${networkPreVerificationGas}`);
 
-    const minimumAcceptablePreVerificationGas =
-      Number(networkPreVerificationGas) * preVerificationGasThresholdPercentage;
+      const minimumAcceptablePreVerificationGas =
+        Number(networkPreVerificationGas) *
+        preVerificationGasThresholdPercentage;
 
-    if (minimumAcceptablePreVerificationGas > Number(preVerificationGas)) {
-      log.info(
-        `preVerificationGas in userOp: ${preVerificationGas} is lower than minimumAcceptablePreVerificationGas: ${minimumAcceptablePreVerificationGas}`,
-      );
-      throw new RpcError(
-        `preVerificationGas in userOp: ${preVerificationGas} is lower than minimumAcceptablePreVerificationGas: ${minimumAcceptablePreVerificationGas}`,
-        BUNDLER_ERROR_CODES.PRE_VERIFICATION_GAS_TOO_LOW,
-      );
+      if (minimumAcceptablePreVerificationGas > Number(preVerificationGas)) {
+        log.info(
+          `preVerificationGas in userOp: ${preVerificationGas} is lower than minimumAcceptablePreVerificationGas: ${minimumAcceptablePreVerificationGas}`,
+        );
+        throw new RpcError(
+          `preVerificationGas in userOp: ${preVerificationGas} is lower than minimumAcceptablePreVerificationGas: ${minimumAcceptablePreVerificationGas}`,
+          BUNDLER_ERROR_CODES.PRE_VERIFICATION_GAS_TOO_LOW,
+        );
+      }
     }
 
     log.info(


### PR DESCRIPTION
# 📖 Context
## Type of change

<!-- Please delete options that are not relevant. -->

- [x] Non-breaking change (backwards compatible)

## Why are we doing this?

Useful for development and for certain chains where we have problems with gas estimation.

## What did we do?

- If a chain ID  is included in `config.disableFeeValidation` the bundler won't check the PVG on `eth_sendUserOperation`

## How Has This Been Tested?
- Manually
