### PR TITLE
fix(eth_senduseroperation): allow 0 for request ID & support gas limit markup

### DIFF
--- a/config/default.json
+++ b/config/default.json
@@ -1165,6 +1165,9 @@
   },
   "disableFeeValidation": [],
   "adminAddresses": [],
+  "callGasLimitMarkup": {
+    "100": 20000
+  },
   "hardcodedGasLimits": {
     "84532": {
       "verificationGasLimit": 2000000,


### PR DESCRIPTION
# 📖 Context
## Type of change

- [x] Non-breaking change (backwards compatible)

## Why are we doing this?

- We incorrectly checked the JSON-RPC request ID, and it would generate a new request ID in case the client sent 0, and we should always return whatever the client sent.
- Gnosis estimate gas returns a low gas limit consistently.

## What did we do?

- Check if the request ID is defined and not "truthy".
- Allow adding a markup (in wei) to the call gas limit returned from simulation to handle cases where the RPC doesn't return the correct estimate from `eth_estimateGas` (for example on Gnosis).