### PR TITLE
Refactor/minor things before chain integrations

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -25,3 +25,6 @@ dist/
 *.code-workspace
 config/development.json
 config/production.json
+
+# Random scripts that we shouldn't commit
+dont-commit/

--- a/config/default.json
+++ b/config/default.json
@@ -3,7 +3,7 @@
     "fundRelayers": true
   },
   "health": {
-    "checkRelayers": true
+    "checkRelayers": false
   },
   "config": {
     "validate": true
@@ -1045,7 +1045,7 @@
   "networksNotSupportingEthCallStateOverrides": [
     1101, 81, 592, 169, 1715, 7116, 9980, 88882, 88888, 81457, 666666666, 2442,
     8101902, 7001, 196, 195, 167009, 713715, 167000, 1328, 1329, 997, 995,
-    28882, 288, 920637907288165, 4202, 1135
+    28882, 288, 920637907288165
   ],
   "trustWalletSupportedNetworks": [137, 56, 204, 42161, 10, 8453],
   "networksNotSupportingEthCallBytecodeStateOverrides": [

--- a/src/common/status/StatusService.test.ts
+++ b/src/common/status/StatusService.test.ts
@@ -142,7 +142,9 @@ describe("StatusService", () => {
       expect(errors).toEqual([]);
       expect(durationSeconds).toBeGreaterThan(0);
     });
+  });
 
+  describe("checkMasterAccount", () => {
     it("should return an error if the master account was never funded", async () => {
       // we mock only the services that are used
       const statusService = new StatusService({
@@ -170,9 +172,11 @@ describe("StatusService", () => {
       });
 
       const { durationSeconds, errors } =
-        await statusService.checkRelayers(chainId);
+        await statusService.checkMasterAccount(chainId);
 
-      expect(errors).toEqual([`Relayer for chainId: ${chainId} is not funded`]);
+      expect(errors).toEqual([
+        `Master account for chainId: ${chainId} is not funded`,
+      ]);
       expect(durationSeconds).toBeGreaterThan(0);
     });
   });


### PR DESCRIPTION
# 📖 Context
## Type of change

- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Why are we doing this?

- There was a problem with Lisk & SDK gas offsets
- Relayer balance accounting caused flaky healthchecks

## What did we do?

- Enable balance state overrides on Lisk testnet & mainnet
- Separate master account balance check from relayer balance check
- Don't check relayer balance in healthcheck by default (not necessary)

## How Has This Been Tested?

- Tests pass
- Tested using script from @VGabriel45 that reproduces the client's issue